### PR TITLE
MVNorm

### DIFF
--- a/scripts/mcmc_demo.py
+++ b/scripts/mcmc_demo.py
@@ -38,7 +38,10 @@ def main():
         log_kcat=ind_prior_from_truth(true_parameters.log_kcat, 0.1),
         log_enzyme=ind_prior_from_truth(true_parameters.log_enzyme, 0.1),
         log_drain=ind_prior_from_truth(true_parameters.log_drain, 0.1),
-        dgf=ind_prior_from_truth(true_parameters.dgf, 0.1),
+        dgf=(
+            ind_prior_from_truth(true_parameters.dgf, 0.1)[0], 
+            jnp.diag(ind_prior_from_truth(true_parameters.dgf, 0.1)[1])
+        ),
         log_km=ind_prior_from_truth(true_parameters.log_km, 0.1),
         log_conc_unbalanced=ind_prior_from_truth(
             true_parameters.log_conc_unbalanced, 0.1

--- a/scripts/mcmc_demo.py
+++ b/scripts/mcmc_demo.py
@@ -39,8 +39,8 @@ def main():
         log_enzyme=ind_prior_from_truth(true_parameters.log_enzyme, 0.1),
         log_drain=ind_prior_from_truth(true_parameters.log_drain, 0.1),
         dgf=(
-            ind_prior_from_truth(true_parameters.dgf, 0.1)[0], 
-            jnp.diag(ind_prior_from_truth(true_parameters.dgf, 0.1)[1])
+            ind_prior_from_truth(true_parameters.dgf, 0.1)[0],
+            jnp.diag(ind_prior_from_truth(true_parameters.dgf, 0.1)[1]),
         ),
         log_km=ind_prior_from_truth(true_parameters.log_km, 0.1),
         log_conc_unbalanced=ind_prior_from_truth(

--- a/src/enzax/mcmc.py
+++ b/src/enzax/mcmc.py
@@ -67,7 +67,9 @@ def mv_normal_prior_logdensity(
     prior: tuple[Float[Array, "_"], Float[Array, "_ _"]],
 ):
     """Total log density for an multivariate normal distribution."""
-    return jnp.sum(multivariate_normal.logpdf(param, mean=prior[0], cov=prior[1]))
+    return jnp.sum(
+        multivariate_normal.logpdf(param, mean=prior[0], cov=prior[1])
+    )
 
 
 def posterior_logdensity_amm(

--- a/src/enzax/mcmc.py
+++ b/src/enzax/mcmc.py
@@ -40,7 +40,7 @@ class AllostericMichaelisMentenPriorSet:
     log_kcat: Float[Array, "2 n_enzyme"]
     log_enzyme: Float[Array, "2 n_enzyme"]
     log_drain: Float[Array, "2 n_drain"]
-    dgf: Float[Array, "2 n_metabolite"]
+    dgf: tuple[Float[Array, "n_metabolite"], Float[Array, "n_metabolite n_metabolite"]]
     log_km: Float[Array, "2 n_km"]
     log_ki: Float[Array, "2 n_ki"]
     log_conc_unbalanced: Float[Array, "2 n_unbalanced"]
@@ -100,7 +100,7 @@ def posterior_logdensity_amm(
         ind_normal_prior_logdensity(parameters.log_kcat, prior.log_kcat)
         + ind_normal_prior_logdensity(parameters.log_enzyme, prior.log_enzyme)
         + ind_normal_prior_logdensity(parameters.log_drain, prior.log_drain)
-        + ind_normal_prior_logdensity(parameters.dgf, prior.dgf)
+        + mv_normal_prior_logdensity(parameters.dgf, prior.dgf)
         + ind_normal_prior_logdensity(parameters.log_km, prior.log_km)
         + ind_normal_prior_logdensity(
             parameters.log_conc_unbalanced, prior.log_conc_unbalanced

--- a/src/enzax/mcmc.py
+++ b/src/enzax/mcmc.py
@@ -40,7 +40,10 @@ class AllostericMichaelisMentenPriorSet:
     log_kcat: Float[Array, "2 n_enzyme"]
     log_enzyme: Float[Array, "2 n_enzyme"]
     log_drain: Float[Array, "2 n_drain"]
-    dgf: tuple[Float[Array, "n_metabolite"], Float[Array, "n_metabolite n_metabolite"]]
+    dgf: tuple[
+        Float[Array, " n_metabolite"],
+        Float[Array, " n_metabolite n_metabolite"],
+    ]
     log_km: Float[Array, "2 n_km"]
     log_ki: Float[Array, "2 n_ki"]
     log_conc_unbalanced: Float[Array, "2 n_unbalanced"]
@@ -62,9 +65,10 @@ def ind_normal_prior_logdensity(param, prior: Float[Array, "2 _"]):
     """Total log density for an independent normal distribution."""
     return norm.logpdf(param, loc=prior[0], scale=prior[1]).sum()
 
+
 def mv_normal_prior_logdensity(
-    param: Float[Array, "_"],
-    prior: tuple[Float[Array, "_"], Float[Array, "_ _"]],
+    param: Float[Array, " _"],
+    prior: tuple[Float[Array, " _"], Float[Array, " _ _"]],
 ):
     """Total log density for an multivariate normal distribution."""
     return jnp.sum(

--- a/src/enzax/mcmc.py
+++ b/src/enzax/mcmc.py
@@ -9,7 +9,7 @@ import chex
 import jax
 from jax._src.random import KeyArray
 import jax.numpy as jnp
-from jax.scipy.stats import norm
+from jax.scipy.stats import norm, multivariate_normal
 from jaxtyping import Array, Float, PyTree, ScalarLike
 
 from enzax.kinetic_model import (
@@ -61,6 +61,13 @@ class AdaptationKwargs(TypedDict):
 def ind_normal_prior_logdensity(param, prior: Float[Array, "2 _"]):
     """Total log density for an independent normal distribution."""
     return norm.logpdf(param, loc=prior[0], scale=prior[1]).sum()
+
+def mv_normal_prior_logdensity(
+    param: Float[Array, "_"],
+    prior: tuple[Float[Array, "_"], Float[Array, "_ _"]],
+):
+    """Total log density for an multivariate normal distribution."""
+    return jnp.sum(multivariate_normal.logpdf(param, mean=prior[0], cov=prior[1]))
 
 
 def posterior_logdensity_amm(


### PR DESCRIPTION
# Summary

Includes multivariate normal priors for dGfs. Updated the relevant info in the mcmc_demo.py and mcmc.py files.
It gets essentially the sample mcmc means and stds as the example that only uses the 1d prior for dGfs

Checklist:

- [x] tests pass
- [x] `README.md` up to date 
- [x] docs up to date
- [x] link to any relevant issues
