### PR TITLE
Decouple parameters and models

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,26 +26,23 @@ from jax import numpy as jnp
 
 guess = jnp.full((5,) 0.01)
 
-steady_state = get_kinetic_model_steady_state(methionine.model, guess)
+steady_state = get_steady_state(methionine.model, guess, methionine.parameters)
 ```
 
 ### Find a steady state's Jacobian with respect to all parameters
 
 ```python
 import jax
-from enzax.examples import methionine
-from enzax.steady_state import get_kinetic_model_steady_state
+from enzax.examples.methionine import model, parameters
+from enzax.steady_state import get_steady_state
 from jax import numpy as jnp
-from jaxtyping import PyTree
 
-guess = jnp.full((5,) 0.01)
-model = methionine.model
+guess = jnp.full((5,), 0.01)
 
-def get_steady_state_from_params(parameters: PyTree):
-    """Get the steady state with a one-argument non-pure function."""
-    _model = RateEquationModel(parameters, model.structure)
-    return get_kinetic_model_steady_state(_model, guess)
-
-jacobian = jax.jacrev(get_steady_state_from_params)(model.parameters)
-
+jacobian = jax.jacrev(get_steady_state, argnums=2)(model, guess, parameters)
+jacobian["log_kcat"]["GNMT1"]
+```
+```
+Array([-3.83561770e-07, -9.66801636e-06,  3.38183140e-10,  3.15564928e-09,
+        5.28588273e-08], dtype=float64, weak_type=True)
 ```

--- a/docs/api/kinetic_model.md
+++ b/docs/api/kinetic_model.md
@@ -4,7 +4,6 @@
       filters:
         - "!check"
       members:
-        - KineticModelStructure
         - KineticModel
         - KineticModelSbml
         - RateEquationModel

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -23,13 +23,9 @@ First we import some enzax classes, as well as [equinox](https://github.com/patr
 ```python
 import equinox as eqx
 
-from jax import numpy as jnp
 import numpy as np
 
-from enzax.kinetic_model import (
-    KineticModelStructure,
-    RateEquationModel,
-)
+from enzax.kinetic_model import RateEquationModel
 from enzax.rate_equations import (
     AllostericReversibleMichaelisMenten,
     ReversibleMichaelisMenten,
@@ -37,17 +33,22 @@ from enzax.rate_equations import (
 
 ```
 
-Next we specify our model's structure by providing a stoichiometric matrix and saying which of its rows represent state variables (aka "balanced species") and which reactions have which rate equations.
+Next we start specifying our model's structure by providing stoichiometric coefficients for its reactions and saying which species represent ODE state variables (aka which ones are "balanced").
 
 ```python
 stoichiometry = {
-    "r1": {"m1e": -1, "m1c": 1},
-    "r2": {"m1c": -1, "m2c": 1},
-    "r3": {"m2c": -1, "m2e": 1},
+    "r1": {"m1e": -1.0, "m1c": 1.0},
+    "r2": {"m1c": -1.0, "m2c": 1.0},
+    "r3": {"m2c": -1.0, "m2e": 1.0},
 }
 reactions = ["r1", "r2", "r3"]
 species = ["m1e", "m1c", "m2c", "m2e"]
 balanced_species = ["m1c", "m2c"]
+```
+
+Next we specify the model's rate equations. Note that the order of the equations should match our `reactions` list and that the indexes that refer to species, like `ix_allosteric_activators` and `ix_ki_species` should match the order of the `species` list.
+
+```python
 rate_equations = [
     AllostericReversibleMichaelisMenten(
         ix_allosteric_activators=np.array([2]), subunits=1
@@ -57,74 +58,65 @@ rate_equations = [
     ),
     ReversibleMichaelisMenten(water_stoichiometry=0.0),
 ]
-structure = KineticModelStructure(
+```
+
+Now we can make a RateEquationModel object
+
+```python
+model = RateEquationModel(
     stoichiometry=stoichiometry,
     species=species,
+    reactions=reactions,
     balanced_species=balanced_species,
     rate_equations=rate_equations,
 )
+
 ```
 
-Next we define what a set of kinetic parameters looks like for our problem, and provide a set of parameters matching this definition:
+Next we specify a set of kinetic parameters as a dictionary:
 
 ```python
-class ParameterDefinition(eqx.Module):
-    log_substrate_km: dict[int, Array]
-    log_product_km: dict[int, Array]
-    log_kcat: dict[int, Scalar]
-    log_enzyme: dict[int, Array]
-    log_ki: dict[int, Array]
-    dgf: Array
-    temperature: Scalar
-    log_conc_unbalanced: Array
-    log_dc_inhibitor: dict[int, Array]
-    log_dc_activator: dict[int, Array]
-    log_tc: dict[int, Array]
+from jax import numpy as jnp
 
-parameters = ParameterDefinition(
-    log_substrate_km={
+parameters = {
+    "log_substrate_km": {
         "r1": jnp.array([0.1]),
         "r2": jnp.array([0.5]),
         "r3": jnp.array([-1.0]),
     },
-    log_product_km={
+    "log_product_km": {
         "r1": jnp.array([-0.2]),
         "r2": jnp.array([0.0]),
         "r3": jnp.array([0.5]),
     },
-    log_kcat={"r1": jnp.array(-0.1), "r2": jnp.array(0.0), "r3": jnp.array(0.1)},
-    dgf=jnp.array([-3.0, -1.0]),
-    log_ki={"r1": jnp.array([]), "r2": jnp.array([1.0]), "r3": jnp.array([])},
-    temperature=jnp.array(310.0),
-    log_enzyme={
+    "log_kcat": {"r1": jnp.array(-0.1), "r2": jnp.array(0.0), "r3": jnp.array(0.1)},
+    "dgf": jnp.array([-3.0, -1.0]),
+    "log_ki": {"r1": jnp.array([]), "r2": jnp.array([1.0]), "r3": jnp.array([])},
+    "temperature": jnp.array(310.0),
+    "log_enzyme": {
         "r1": jnp.log(jnp.array(0.3)),
         "r2": jnp.log(jnp.array(0.2)),
         "r3": jnp.log(jnp.array(0.1)),
     },
-    log_conc_unbalanced=jnp.log(jnp.array([0.5, 0.1])),
-    log_tc={"r1": jnp.array(-0.2), "r2": jnp.array(0.3)},
-    log_dc_activator={"r1": jnp.array([-0.1]), "r2": jnp.array([])},
-    log_dc_inhibitor={"r1": jnp.array([]), "r2": jnp.array([0.2])},
-)
+    "log_conc_unbalanced": jnp.log(jnp.array([0.5, 0.1])),
+    "log_tc": {"r1": jnp.array(-0.2), "r2": jnp.array(0.3)},
+    "log_dc_activator": {"r1": jnp.array([-0.1]), "r2": jnp.array([])},
+    "log_dc_inhibitor": {"r1": jnp.array([]), "r2": jnp.array([0.2])},
+}
 ```
+
 Note that the parameters use `jnp` whereas the structure uses `np`. This is because we want JAX to trace the parameters, whereas the structure should be static. Read more about this [here](https://jax.readthedocs.io/en/latest/notebooks/thinking_in_jax.html#static-vs-traced-operations).
-
-Now we can declare our model:
-
-```python
-model = RateEquationModel(structure, parameters)
-```
 
 To test out the model, we can see if it returns some fluxes and state variable rates when provided a set of balanced species concentrations:
 
 ```python
 conc = jnp.array([0.43658744, 0.12695706])
-flux = model.flux(conc)
+flux = model.flux(conc, parameters)
 flux
 ```
 
 ```python
-dcdt = model.dcdt(conc)
+dcdt = model.dcdt(conc, parameters)
 dcdt
 ```
 
@@ -135,28 +127,18 @@ Enzax provides a few example kinetic models, including [`methionine`](https://gi
 Here is how to find this model's steady state (and its parameter gradients) using enzax's `get_kinetic_model_steady_state` function:
 
 ```python
-from enzax.examples import methionine
-from enzax.steady_state import get_kinetic_model_steady_state
+from enzax.examples.methionine import model, parameters
+from enzax.steady_state import get_steady_state
 from jax import numpy as jnp
 
 guess = jnp.full((5,) 0.01)
 
-steady_state = get_kinetic_model_steady_state(methionine.model, guess)
+steady_state = get_steady_state(model, guess, parameters)
 ```
 
-To access the Jacobian of this steady state with respect to the model's parameters, we can wrap `get_kinetic_model_steady_state` in a function that has a set of parameters as its only argument, then use JAX's [`jacrev`](https://jax.readthedocs.io/en/latest/_autosummary/jax.jacrev.html) function:
+To access the Jacobian of this steady state with respect to the model's parameters, we can use JAX's [`jacrev`](https://jax.readthedocs.io/en/latest/_autosummary/jax.jacrev.html) function:
 
 ```python
-import jax
-from jaxtyping import PyTree
-
-guess = jnp.full((5,) 0.01)
-model = methionine.model
-
-def get_steady_state_from_params(parameters: PyTree):
-    """Get the steady state with a one-argument non-pure function."""
-    _model = RateEquationModel(parameters, model.structure)
-    return get_kinetic_model_steady_state(_model, guess)
-
-jacobian = jax.jacrev(get_steady_state_from_params)(model.parameters)
+jacobian = jax.jacrev(get_steady_state, argnums=2)(model, guess, parameters)
+jacobian
 ```

--- a/docs/statistical_modelling.md
+++ b/docs/statistical_modelling.md
@@ -17,8 +17,7 @@ The simplest way to do this is to not include the known parameters in the kineti
 In this example, we fix some parameters of the `methionine` model provided by enzax, a medium-to-small sized model that describes the mammalian methionine cycle. We can load this model and its parameters as follows:
 
 ```python
-from enzax.examples import methionine
-true_parameters = methionine.parameters
+from enzax.examples.methionine import parameters as true_parameters
 true_parameters
 ```
 
@@ -26,10 +25,7 @@ The parameters are a pretty large dictionary. Suppose we want to make a statisti
 
 ```python
 def get_free_params(params):
-    return (
-        params["log_kcat"]["MAT1"],
-        params["temperature"],
-    )
+    return params["log_kcat"]["MAT1"], params["temperature"]
 ```
 
 Next, we use some functions from the library [equinox](https://github.com/patrick-kidger/equinox)---`tree_at` and `partition`---as well as `jax.tree.map`to create dictionaries of free and fixed parameters based on our function.
@@ -71,7 +67,7 @@ new_parameters = eqx.combine(new_free_parameters, fixed_parameters)
 new_parameters
 ```
 
-Note that this method of splitting fixed and free paremeters works for arbitary pytrees, and can easily be adjusted so that the fixed parameters rather than the free ones are user-specified.
+Note that this method of splitting fixed and free parameters works for arbitrary pytrees, and can easily be adjusted so that the fixed parameters rather than the free ones are user-specified.
 
 ## Posterior sampling
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "enzax"
-version = "0.1.2"
+version = "0.2.1"
 description = "Differentiable models of enzyme-catalysed reaction networks"
 authors = [
     {name = "Teddy Groves", email = "tedgro@dtu.dk"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ known-first-party = ["enzax"]
 
 [dependency-groups]
 dev = [
-    "pytest>=8.3.3",
     "pytest-cov>=5.0.0",
     "pre-commit>=3.8.0",
+    "pytest==8.3.5",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "enzax"
-version = "0.2.0"
+version = "0.1.2"
 description = "Differentiable models of enzyme-catalysed reaction networks"
 authors = [
     {name = "Teddy Groves", email = "tedgro@dtu.dk"},
 ]
 dependencies = [
     "blackjax>=1.2.1",
-    "diffrax>=0.6.0",
+    "diffrax>=0.7.0",
     "jaxtyping>=0.2.38",
     "arviz>=0.19.0",
     "equinox>=0.11.12",
@@ -32,6 +32,9 @@ docs = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.pdm]
+distribution = true
 
 [tool.ruff]
 line-length = 80

--- a/scripts/steady_state_demo.py
+++ b/scripts/steady_state_demo.py
@@ -1,52 +1,36 @@
 """Demonstration of how to find a steady state and its gradients with enzax."""
 
 import time
-from enzax.kinetic_model import RateEquationModel
 
 import jax
 from jax import numpy as jnp
 
-from enzax.examples import methionine
-from enzax.steady_state import get_kinetic_model_steady_state
-from jaxtyping import PyTree
+from enzax.examples import linear as example
+from enzax.steady_state import get_steady_state
 
-BAD_GUESS = jnp.full((5,), 0.01)
-GOOD_GUESS = jnp.array(
-    [
-        4.233000e-05,  # met-L
-        3.099670e-05,  # amet
-        2.170170e-07,  # ahcys
-        3.521780e-06,  # hcys
-        6.534400e-06,  # 5mthf
-    ]
-)
+BAD_GUESS = jnp.full(example.steady_state.shape, 0.01)
+GOOD_GUESS = example.steady_state
 
 
 def main():
     """Function for testing the steady state solver."""
-    model = methionine.model
+    model = example.model
+    parameters = example.parameters
+
+    __import__("pdb").set_trace()
     # compare good and bad guess
     for guess in [BAD_GUESS, GOOD_GUESS]:
-
-        def get_steady_state_from_params(parameters: PyTree):
-            """Get the steady state from just parameters.
-
-            This lets us get the Jacobian wrt (just) the parameters.
-            """
-            _model = RateEquationModel(parameters, model.structure)
-            return get_kinetic_model_steady_state(_model, guess)
-
         # solve once for jitting
-        get_kinetic_model_steady_state(model, GOOD_GUESS)
-        jax.jacrev(get_steady_state_from_params)(model.parameters)
+        steady = get_steady_state(model, GOOD_GUESS, parameters)
+        jax.jacrev(model.dcdt, argnums=1)(steady, parameters)
         # timer on
         start = time.time()
-        conc_steady = get_kinetic_model_steady_state(model, guess)
-        jac = jax.jacrev(get_steady_state_from_params)(model.parameters)
+        conc_steady = get_steady_state(model, guess, parameters)
+        jac = jax.jacrev(model.dcdt, argnums=1)(conc_steady, parameters)
         # timer off
         runtime = (time.time() - start) * 1e3
-        sv = model.dcdt(jnp.array(0.0), conc=conc_steady)
-        flux = model.flux(conc_steady)
+        sv = model.dcdt(conc_steady, parameters)
+        flux = model.flux(conc_steady, parameters)
         print(f"Results with starting guess {guess}:")
         print(f"\tRun time in milliseconds: {round(runtime, 4)}")
         print(f"\tSteady state concentration: {conc_steady}")

--- a/scripts/steady_state_demo.py
+++ b/scripts/steady_state_demo.py
@@ -17,7 +17,6 @@ def main():
     model = example.model
     parameters = example.parameters
 
-    __import__("pdb").set_trace()
     # compare good and bad guess
     for guess in [BAD_GUESS, GOOD_GUESS]:
         # solve once for jitting

--- a/src/enzax/examples/linear.py
+++ b/src/enzax/examples/linear.py
@@ -11,9 +11,9 @@ from enzax.rate_equations import (
 
 
 stoichiometry = {
-    "r1": {"m1e": -1, "m1c": 1},
-    "r2": {"m1c": -1, "m2c": 1},
-    "r3": {"m2c": -1, "m2e": 1},
+    "r1": {"m1e": -1.0, "m1c": 1.0},
+    "r2": {"m1c": -1.0, "m2c": 1.0},
+    "r3": {"m2c": -1.0, "m2e": 1.0},
 }
 reactions = ["r1", "r2", "r3"]
 species = ["m1e", "m1c", "m2c", "m2e"]

--- a/src/enzax/examples/linear.py
+++ b/src/enzax/examples/linear.py
@@ -3,10 +3,7 @@
 import numpy as np
 from jax import numpy as jnp
 
-from enzax.kinetic_model import (
-    RateEquationKineticModelStructure,
-    RateEquationModel,
-)
+from enzax.kinetic_model import RateEquationModel
 from enzax.rate_equations import (
     AllostericReversibleMichaelisMenten,
     ReversibleMichaelisMenten,
@@ -30,7 +27,7 @@ rate_equations = [
     ),
     ReversibleMichaelisMenten(water_stoichiometry=0.0),
 ]
-structure = RateEquationKineticModelStructure(
+model = RateEquationModel(
     stoichiometry=stoichiometry,
     species=species,
     reactions=reactions,
@@ -67,6 +64,4 @@ parameters = dict(
     log_dc_activator={"r1": jnp.array([-0.1]), "r2": jnp.array([])},
     log_dc_inhibitor={"r1": jnp.array([]), "r2": jnp.array([0.2])},
 )
-true_model = RateEquationModel(structure=structure, parameters=parameters)
 steady_state = jnp.array([0.43658744, 0.12695706])
-model = RateEquationModel(parameters, structure)

--- a/src/enzax/examples/methionine.py
+++ b/src/enzax/examples/methionine.py
@@ -8,10 +8,7 @@ https://doi.org/10.1021/acssynbio.3c00662
 import numpy as np
 from jax import numpy as jnp
 
-from enzax.kinetic_model import (
-    RateEquationKineticModelStructure,
-    RateEquationModel,
-)
+from enzax.kinetic_model import RateEquationModel
 from enzax.rate_equations import (
     AllostericIrreversibleMichaelisMenten,
     Drain,
@@ -204,7 +201,7 @@ parameters = dict(
     },
 )
 
-structure = RateEquationKineticModelStructure(
+model = RateEquationModel(
     stoichiometry=stoichiometry,
     species=species,
     reactions=reactions,
@@ -253,4 +250,3 @@ steady_state = jnp.array(
         6.534400e-06,  # 5mthf
     ]
 )
-model = RateEquationModel(parameters, structure)

--- a/src/enzax/kinetic_model.py
+++ b/src/enzax/kinetic_model.py
@@ -1,15 +1,13 @@
 """Module containing enzax's definition of a kinetic model."""
 
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from typing import Any
 
 import equinox as eqx
 import jax.numpy as jnp
 import numpy as np
-from jax.tree_util import register_pytree_node_class
-from jaxtyping import Array, Float, PyTree, ScalarLike, jaxtyped
+from jaxtyping import Array, Float, PyTree
 from numpy.typing import NDArray
-from typeguard import typechecked
 
 from enzax.rate_equation import RateEquation
 
@@ -18,27 +16,18 @@ def get_ix_from_list(s: str, list_of_strings: list[str]):
     return next(i for i, si in enumerate(list_of_strings) if si == s)
 
 
-def get_conc(balanced, log_unbalanced, structure):
-    conc = jnp.zeros(structure.S.shape[0])
-    conc = conc.at[structure.balanced_species_ix].set(balanced)
-    conc = conc.at[structure.unbalanced_species_ix].set(jnp.exp(log_unbalanced))
-    return conc
-
-
-@jaxtyped(typechecker=typechecked)
-@register_pytree_node_class
-class KineticModelStructure:
+class KineticModel(eqx.Module):
     """Structural information about a kinetic model."""
 
-    stoichiometry: dict[str, dict[str, float]]
-    species: list[str]
-    reactions: list[str]
-    balanced_species: list[str]
-    unbalanced_species: list[str]
-    species_to_dgf_ix: NDArray[np.int16]
-    balanced_species_ix: NDArray[np.int16]
-    unbalanced_species_ix: NDArray[np.int16]
-    S: NDArray[np.float64]
+    stoichiometry: dict[str, dict[str, float]] = eqx.field(static=True)
+    species: list[str] = eqx.field(static=True)
+    reactions: list[str] = eqx.field(static=True)
+    balanced_species: list[str] = eqx.field(static=True)
+    unbalanced_species: list[str] = eqx.field(static=True)
+    species_to_dgf_ix: NDArray[np.int16] = eqx.field(static=True)
+    balanced_species_ix: NDArray[np.int16] = eqx.field(static=True)
+    unbalanced_species_ix: NDArray[np.int16] = eqx.field(static=True)
+    S: NDArray[np.float64] = eqx.field(static=True)
 
     def __init__(
         self,
@@ -89,17 +78,52 @@ class KineticModelStructure:
     def tree_unflatten(cls, aux_data, children):
         return cls(*children)
 
+    def get_conc(self, balanced, log_unbalanced):
+        conc = jnp.zeros(self.S.shape[0])
+        conc = conc.at[self.balanced_species_ix].set(balanced)
+        conc = conc.at[self.unbalanced_species_ix].set(jnp.exp(log_unbalanced))
+        return conc
 
-class RateEquationKineticModelStructure(KineticModelStructure):
+    @abstractmethod
+    def flux(
+        self,
+        conc_balanced: Float[Array, " n_balanced"],
+        parameters: PyTree,
+    ) -> Float[Array, " n"]: ...
+
+    def dcdt(
+        self,
+        conc: Float[Array, " n_balanced"],
+        parameters: PyTree,
+    ) -> Float[Array, " n_balanced"]:
+        """Get the rate of change of balanced species concentrations.
+
+        :param conc: a one dimensional array of positive floats representing concentrations of balanced species. Must have same size as self.structure.ix_balanced
+
+        :param parameters: A PyTree of parameters.
+
+        :return: a one dimensional array of floats representing the rate of change of balanced species concentrations. Has same size as self.structure.ix_balanced.
+        """  # Noqa: E501
+        v = self.flux(conc, parameters)
+        sv = self.S @ v
+        return jnp.array(sv[self.balanced_species_ix])
+
+    def __call__(self, t, y, parameters):
+        return self.dcdt(y, parameters)
+
+
+class RateEquationModel(KineticModel):
+    """A kinetic model that specifies its fluxes using RateEquation objects."""
+
     rate_equations: list[RateEquation]
 
     def __init__(
         self,
+        rate_equations: list[RateEquation],
         stoichiometry,
         species,
         reactions,
         balanced_species,
-        rate_equations,
         species_to_dgf_ix=None,
     ):
         super().__init__(
@@ -107,61 +131,14 @@ class RateEquationKineticModelStructure(KineticModelStructure):
             species,
             reactions,
             balanced_species,
-            species_to_dgf_ix,
+            species_to_dgf_ix=None,
         )
         self.rate_equations = rate_equations
 
-    def tree_flatten(self):
-        children = (
-            self.stoichiometry,
-            self.species,
-            self.reactions,
-            self.balanced_species,
-            self.species_to_dgf_ix,
-            self.rate_equations,
-        )
-        aux_data = None
-        return children, aux_data
-
-
-class KineticModel(eqx.Module, ABC):
-    """Abstract base class for kinetic models."""
-
-    parameters: PyTree
-    structure: KineticModelStructure = eqx.field(static=True)
-
-    @abstractmethod
     def flux(
         self,
         conc_balanced: Float[Array, " n_balanced"],
-    ) -> Float[Array, " n"]: ...
-
-    @eqx.filter_jit
-    def dcdt(
-        self, t: ScalarLike, conc: Float[Array, " n_balanced"], args=None
-    ) -> Float[Array, " n_balanced"]:
-        """Get the rate of change of balanced species concentrations.
-
-        Note that the signature is as required for a Diffrax vector field function, hence the redundant variable t and the weird name "args".
-
-        :param t: redundant variable representing time.
-
-        :param conc: a one dimensional array of positive floats representing concentrations of balanced species. Must have same size as self.structure.ix_balanced
-
-        """  # Noqa: E501
-        v = self.flux(conc)
-        sv = self.structure.S @ v
-        return jnp.array(sv[self.structure.balanced_species_ix])
-
-
-class RateEquationModel(KineticModel):
-    """A kinetic model that specifies its fluxes using RateEquation objects."""
-
-    structure: RateEquationKineticModelStructure
-
-    def flux(
-        self,
-        conc_balanced: Float[Array, " n_balanced"],
+        parameters: PyTree,
     ) -> Float[Array, " n"]:
         """Get fluxes from balanced species concentrations.
 
@@ -170,20 +147,16 @@ class RateEquationModel(KineticModel):
         :return: a one dimensional array of (possibly negative) floats representing reaction fluxes. Has same size as number of columns of self.structure.S.
 
         """  # Noqa: E501
-        conc = get_conc(
-            conc_balanced,
-            self.parameters["log_conc_unbalanced"],
-            self.structure,
-        )
+        conc = self.get_conc(conc_balanced, parameters["log_conc_unbalanced"])
         flux_list = []
         for reaction_ix, (reaction_id, rate_equation) in enumerate(
-            zip(self.structure.reactions, self.structure.rate_equations)
+            zip(self.reactions, self.rate_equations)
         ):
             ipt = rate_equation.get_input(
-                parameters=self.parameters,
+                parameters=parameters,
                 reaction_id=reaction_id,
-                reaction_stoichiometry=self.structure.S[:, reaction_ix],
-                species_to_dgf_ix=self.structure.species_to_dgf_ix,
+                reaction_stoichiometry=self.S[:, reaction_ix],
+                species_to_dgf_ix=self.species_to_dgf_ix,
             )
             flux_list.append(rate_equation(conc, ipt))
         return jnp.array(flux_list)
@@ -195,11 +168,12 @@ class KineticModelSbml(KineticModel):
     def flux(
         self,
         conc_balanced: Float[Array, " n_balanced"],
+        parameters,
     ) -> Float[Array, " n"]:
         flux = jnp.array(
             self.sym_module(
-                **self.parameters,
-                **dict(zip(self.structure.balanced_species, conc_balanced)),
+                **parameters,
+                **dict(zip(self.balanced_species, conc_balanced)),
             )
         )
         return flux

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -5,15 +5,15 @@ from enzax.examples import linear, methionine
 
 
 @pytest.mark.parametrize(
-    ["model", "steady_state"],
+    ["model", "steady_state", "parameters"],
     [
-        (methionine.model, methionine.steady_state),
-        (linear.model, linear.steady_state),
+        (methionine.model, methionine.steady_state, methionine.parameters),
+        (linear.model, linear.steady_state, linear.parameters),
     ],
 )
-def test_dcdt(model, steady_state):
+def test_dcdt(model, steady_state, parameters):
     """Test for near-zero dcdt at a known steady state."""
 
-    dcdt = model.dcdt(0, steady_state)
+    dcdt = model.dcdt(steady_state, parameters)
     zero = jnp.full((len(steady_state),), 0.0)
     assert jnp.isclose(dcdt, zero).all()


### PR DESCRIPTION
This change removes the distinction between a kinetic model structure and a parameterised kinetic model. Now a kinetic model is essentially a container for a pure flux function (from parameter/state pairs to fluxes) and an ode function (parameter/state pairs to state rates of change). This is nice because it means we can get jacobians wrt both parameters and states, depending on what we want (spoiler - for smart guessing via the implicit function theorem we want to do both). It also means that the KineticModel object and its relatives can be completely static, which makes thinking about JAX stuff easier.

Checklist:

- [x] tests pass
- [ ] `README.md` up to date
- [ ] docs up to date
- [ ] link to any relevant issues
