### PR TITLE
Decouple enzymes from reactions

### DIFF
--- a/src/enzax/rate_equation.py
+++ b/src/enzax/rate_equation.py
@@ -1,7 +1,7 @@
 """Module containing rate equations for enzyme-catalysed reactions."""
 
 from abc import ABC, abstractmethod
-from equinox import Module
+from equinox import Module, AbstractVar
 import numpy as np
 from numpy.typing import NDArray
 
@@ -16,6 +16,8 @@ class RateEquation(Module, ABC):
 
     A rate equation is an equinox [Module](https://docs.kidger.site/equinox/api/module/module/) with a `__call__` method that takes in a 1 dimensional array of concentrations and an arbitrary PyTree of other inputs, returning a scalar value representing a single flux.
     """  # Noqa: E501
+
+    enzyme_id: AbstractVar[str | None]
 
     @abstractmethod
     def get_input(

--- a/src/enzax/rate_equations/drain.py
+++ b/src/enzax/rate_equations/drain.py
@@ -15,6 +15,7 @@ class Drain(RateEquation):
     """A drain reaction."""
 
     sign: float
+    enzyme_id: str | None = eqx.field(default_factory=lambda: None)
 
     def get_input(
         self,

--- a/tests/test_rate_equations.py
+++ b/tests/test_rate_equations.py
@@ -19,7 +19,7 @@ EXAMPLE_PARAMETERS = dict(
     dgf=jnp.array([-3.0, 1.0]),
     log_ki={"r1": jnp.array([1.0])},
     temperature=jnp.array(310.0),
-    log_enzyme={"r1": jnp.log(jnp.array(0.3))},
+    log_enzyme={"r1": jnp.log(jnp.array(0.3)), "e1": jnp.log(jnp.array(0.2))},
     log_conc_unbalanced=jnp.array([]),
     log_tc={"r1": jnp.array(-0.2)},
     log_dc_activator={"r1": jnp.array([-0.1])},
@@ -57,6 +57,23 @@ def test_reversible_michaelis_menten():
     assert jnp.isclose(rate, expected_rate)
 
 
+def test_reversible_michaelis_menten_with_enzyme_id():
+    expected_rate = 0.02895259
+    f = ReversibleMichaelisMenten(
+        ix_ki_species=np.array([], dtype=np.int16),
+        water_stoichiometry=0.0,
+        enzyme_id="e1",
+    )
+    f_input = f.get_input(
+        parameters=EXAMPLE_PARAMETERS,
+        reaction_id="r1",
+        reaction_stoichiometry=EXAMPLE_S[:, 0],
+        species_to_dgf_ix=EXAMPLE_SPECIES_TO_DGF_IX,
+    )
+    rate = f(EXAMPLE_CONC, f_input)
+    assert jnp.isclose(rate, expected_rate)
+
+
 def test_allosteric_irreversible_michaelis_menten():
     expected_rate = 0.05608589
     f = AllostericIrreversibleMichaelisMenten(
@@ -74,12 +91,48 @@ def test_allosteric_irreversible_michaelis_menten():
     assert jnp.isclose(rate, expected_rate)
 
 
+def test_allosteric_irreversible_michaelis_menten_with_enzyme_id():
+    expected_rate = 0.03739059
+    f = AllostericIrreversibleMichaelisMenten(
+        ix_ki_species=np.array([], dtype=np.int16),
+        ix_allosteric_activators=np.array([2], dtype=np.int16),
+        subunits=1,
+        enzyme_id="e1",
+    )
+    f_input = f.get_input(
+        parameters=EXAMPLE_PARAMETERS,
+        reaction_id="r1",
+        reaction_stoichiometry=EXAMPLE_S[:, 0],
+        species_to_dgf_ix=EXAMPLE_SPECIES_TO_DGF_IX,
+    )
+    rate = f(EXAMPLE_CONC, f_input)
+    assert jnp.isclose(rate, expected_rate)
+
+
 def test_allosteric_reversible_michaelis_menten():
     expected_rate = 0.03027414
     f = AllostericReversibleMichaelisMenten(
         ix_ki_species=np.array([], dtype=np.int16),
         ix_allosteric_activators=np.array([2], dtype=np.int16),
         subunits=1,
+    )
+    f_input = f.get_input(
+        parameters=EXAMPLE_PARAMETERS,
+        reaction_id="r1",
+        reaction_stoichiometry=EXAMPLE_S[:, 0],
+        species_to_dgf_ix=EXAMPLE_SPECIES_TO_DGF_IX,
+    )
+    rate = f(EXAMPLE_CONC, f_input)
+    assert jnp.isclose(rate, expected_rate)
+
+
+def test_allosteric_reversible_michaelis_menten_with_enzyme_id():
+    expected_rate = 0.02018276
+    f = AllostericReversibleMichaelisMenten(
+        ix_ki_species=np.array([], dtype=np.int16),
+        ix_allosteric_activators=np.array([2], dtype=np.int16),
+        subunits=1,
+        enzyme_id="e1",
     )
     f_input = f.get_input(
         parameters=EXAMPLE_PARAMETERS,


### PR DESCRIPTION
This change allows you to set an enzyme id when defining a rate equation, as required for e.g. promiscuous enzymes.

Here is how to set an enzyme id:

```python
import numpy as np
from enzax.rate_equations.generalised_mwc import AllostericMichaelisMenten

my_parameters = {
    ...
    log_enzyme: {"e1": -1.1}
}

my_rate_equation = AllostericIrreversibleMichaelisMenten(
    ix_ki_species=np.array([], dtype=np.int16),
    ix_allosteric_activators=np.array([2], dtype=np.int16),
    subunits=1,
    enzyme_id="e1",
)

```

If a rate equation is initialised with an `enzyme_id`, the rate equation should use this id in its `get_input` method to fetch a `log_enzyme` value from the parameters dictionary. If `enzyme_id` is not, the rate equation should look up a log enzyme concentration using the reaction id, i.e. the previous behaviour. 

Checklist:

- [x] tests pass
- [x] `README.md` up to date
- [x] docs up to date
- [ ] link to any relevant issues
